### PR TITLE
fix(ci): correct Build Matrix Verifier workflowId in trusted-ci-aggregate

### DIFF
--- a/.github/scripts/test-trusted-ci-aggregate-status.js
+++ b/.github/scripts/test-trusted-ci-aggregate-status.js
@@ -166,7 +166,7 @@ assert.strictEqual(contract.hasTerminalReporterSet({
 function completedReporterEvent() {
     return {
         id: 900,
-        workflow_id: 345629369,
+        workflow_id: 349562521,
         run_number: 65,
         run_attempt: 2,
         name: 'Build Matrix Verifier',

--- a/.github/scripts/trusted-ci-aggregate-status.js
+++ b/.github/scripts/trusted-ci-aggregate-status.js
@@ -4,7 +4,7 @@ const BOT_LOGIN = 'github-actions[bot]';
 const BOT_ID = 41898282;
 const REPORTER_WORKFLOWS = Object.freeze({
     'Build Matrix Verifier': Object.freeze({
-        workflowId: 345629369,
+        workflowId: 349562521,
         path: '.github/workflows/build-matrix-verifier.yml',
         context: 'Build Matrix Verifier / Exact Source'
     }),


### PR DESCRIPTION
## Summary

- Fixes the `Trusted Exact-Source CI` aggregator workflow that has been failing on every run since the Build Matrix Verifier workflow was introduced
- The `REPORTER_WORKFLOWS` constant in `trusted-ci-aggregate-status.js` had a stale workflowId (`345629369`) for the Build Matrix Verifier — the actual GitHub workflow_id is `349562521`
- This caused `isExactCompletedReporterEvent()` to always return `false` for verifier-triggered aggregator events, preventing the trusted-CI badge from ever going green

## Test plan

- [x] `test-trusted-ci-aggregate-status.js` passes with the corrected workflowId
- [ ] After merge, verify the next `Trusted Exact-Source CI` aggregator run succeeds on Working
- [ ] Confirm the README badge updates from failing to passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kmbvy1cXWBa2gy3MEPUJiJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kmbvy1cXWBa2gy3MEPUJiJ)_