### PR TITLE
Fix MSan canary census and unavailable-instrumentation reporting

### DIFF
--- a/Tests/TestMSanCanary.cpp
+++ b/Tests/TestMSanCanary.cpp
@@ -9,8 +9,8 @@
  * representation written by the out-of-line basic_string::__init stays
  * poisoned and __msan_test_shadow returns >= 0; with the instrumented runtime
  * it returns -1. No uninitialised value is read here, so halt_on_error is
- * irrelevant. In every other build the tests are count-preserving stubs
- * (same pattern as TestVulkanLavapipe.cpp).
+ * irrelevant. In every other build the tests explicitly skip: registration
+ * alone is not evidence that MemorySanitizer instrumentation was verified.
  */
 
 #include "TestFramework.h"
@@ -39,7 +39,7 @@ TEST(MSanCanary_TestTranslationUnitIsInstrumented)
     probe = 1;
     EXPECT_EQ(__msan_test_shadow(&probe, sizeof probe), -1);
 #else
-    EXPECT_TRUE(true);
+    SKIP_TEST("MemorySanitizer instrumentation is unavailable in this build");
 #endif
 }
 
@@ -57,6 +57,6 @@ TEST(MSanCanary_LibcxxStoresUpdateShadow)
     EXPECT_EQ(__msan_test_shadow(onHeap.get(), sizeof(std::string)), -1);
     EXPECT_EQ(__msan_test_shadow(onHeap->data(), onHeap->size()), -1);
 #else
-    EXPECT_TRUE(true);
+    SKIP_TEST("MemorySanitizer instrumentation is unavailable in this build");
 #endif
 }

--- a/Tools/test_source_census.py
+++ b/Tools/test_source_census.py
@@ -53,7 +53,12 @@ TEST_SUPPORT_HEADERS = {"TestFramework.h", "TestWarnings.h"}
 
 # ...which leaves the files whose SUBJECT is the harness. Includes alone cannot
 # distinguish those, so they are named here.
-HARNESS_TESTS = frozenset({"Tests/TestRunnerSemanticsReal.cpp"})
+HARNESS_TESTS = frozenset({
+    "Tests/TestRunnerSemanticsReal.cpp",
+    # Verifies the sanitizer harness and instrumented C++ runtime, not a
+    # test-local copy of engine behavior. Non-MSan builds explicitly skip it.
+    "Tests/TestMSanCanary.cpp",
+})
 
 # A file with no production header still exercises production code if it drives
 # a shipped executable and asserts on the result.

--- a/wiki/advanced/Codebase-Statistics.md
+++ b/wiki/advanced/Codebase-Statistics.md
@@ -1,6 +1,6 @@
 # Codebase Statistics
 
-Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-09-06.
+Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-09-07.
 This source inventory is not readiness evidence. The `stable-v1` Windows 11
 x64 profile remains blocked and uncertified in `docs/site/readiness.json`.
 


### PR DESCRIPTION
The instrumented-libc++ PR (#568) adds sanitizer harness canaries that the source census currently rejects as new mirror tests. On non-MSan builds they also report fabricated passes.

Classify this exact canary file as a harness test and explicitly skip both tests when MSan instrumentation is unavailable. The instrumented branches and their shadow-memory assertions remain unchanged.

Validation: census check passes (7,263 registered tests); actual non-MSan canary harness reports 2 registered, 2 skipped, 0 passed assertions (before: 0 skipped and 2 passed assertions); documentation generators and whitespace checks pass. Independent source review found no issues. An instrumented MSan run is still required; this does not certify #568 or the release.

This companion PR targets #568 so its runtime changes can retain their own validation and review.